### PR TITLE
Feature: Better unit returns and addition of pressure and energy units

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.35.2",
-    "@devhaven/unit-conversion": "0.0.6",
+    "@devhaven/unit-conversion": "workspace:*",
     "astro": "^5.6.1",
     "expressive-code-twoslash": "0.5.3",
     "sharp": "^0.34.2",

--- a/apps/docs/src/content/docs/api-reference.mdx
+++ b/apps/docs/src/content/docs/api-reference.mdx
@@ -24,6 +24,7 @@ import { Conversion } from "@devhaven/unit-conversion";
 
 const conversion = new Conversion({ decimals: 4 });
 const result = conversion.value(10).from("meter").to("foot");
+//    ^?   
 ```
 
 ##### isFloat?: boolean
@@ -39,15 +40,3 @@ const conversion = new Conversion({ isFloat: true });
 const result = conversion.value(10).from("meter").to("foot");
 ```
 
-##### includeUnit?: boolean
-
-- Optional
-- Default: false
-- If true, the conversion result will include the unit as a string.
-
-```ts twoslash
-import { Conversion } from "@devhaven/unit-conversion";
-
-const conversion = new Conversion({ includeUnit: false });
-const result = conversion.value(10).from("meter").to("foot");
-```

--- a/apps/docs/src/content/docs/conversions/energy.mdx
+++ b/apps/docs/src/content/docs/conversions/energy.mdx
@@ -1,0 +1,60 @@
+---
+title: "Energy"
+template: doc
+---
+
+The energy category supports conversions between Joule, Kilojoule, Calorie, Calorie (International Table), Calorie (Thermochemical), Watt-Hour, Kilowatt-Hour and Electron-Volt.
+
+## Supported Units
+
+- Joule `J`
+- Kilojoule `kJ`
+- Calorie `cal`
+- Calorie International Table `cal (IT)`
+- Calorie Thermochemical `cal (th)`
+- Watt-Hour `Wh`
+- Kilowatt-Hour `kWh`
+- Electron-Volt `eV`
+
+## Quick Example
+
+```ts
+import { Conversion } from "@devhaven/unit-conversion";
+
+const convert = new Conversion();
+
+convert.value(0).from("joule").to("kilojoule");      
+convert.value(212).from("kilojoule").to("joule");    
+```
+
+## Common Conversions
+
+### Joule ↔ Kilojoule
+```ts
+convert.value(1).from("joule").to("kilojoule");    
+convert.value(1).from("kilojoule").to("joule");      
+```
+
+### Joule ↔ Electron-Volt
+```ts
+convert.value(1).from("joule").to("electron-volt");    
+convert.value(1).from("electron-volt").to("joule");      
+```
+
+### Kilojoule ↔ Calorie
+```ts
+convert.value(1).from("kilojoule").to("calorie");     
+convert.value(1).from("calorie").to("kilojoule");      
+```
+
+### Calorie ↔ Electron Volt
+```ts
+convert.value(1).from("calorie").to("electron-volt");     
+convert.value(1).from("electron-volt").to("calorie");      
+```
+
+### Calorie ↔ Electron Volt
+```ts
+convert.value(1).from("calorie").to("electron-volt");     
+convert.value(1).from("electron-volt").to("calorie");      
+```

--- a/apps/docs/src/content/docs/conversions/length.mdx
+++ b/apps/docs/src/content/docs/conversions/length.mdx
@@ -44,36 +44,36 @@ convert.value(1).from("meter").to("foot");      // 3.28
 ### Meters ↔ Kilometers
 
 ```ts
-convert.value(1000).from("meter").to("kilometer");      // "1km"
-convert.value(2).from("kilometer").to("meter");         // "2000m"
+convert.value(1000).from("meter").to("kilometer");  
+convert.value(2).from("kilometer").to("meter");     
 ```
 
 ### Meters ↔ Feet
 
 ```ts
-convert.value(1).from("meter").to("foot");      // "3.28ft"
-convert.value(10).from("foot").to("meter");     // "3.05m"
+convert.value(1).from("meter").to("foot");  
+convert.value(10).from("foot").to("meter"); 
 ```
 
 ### Inches ↔ Centimeters
 
 ```ts
-convert.value(1).from("inch").to("centimeter");      // "2.54cm"
-convert.value(30).from("centimeter").to("inch");     // "11.81in"
+convert.value(1).from("inch").to("centimeter");  
+convert.value(30).from("centimeter").to("inch"); 
 ```
 
 ### Miles ↔ Kilometers
 
 ```ts
-convert.value(1).from("mile").to("kilometer");      // "1.609km"
-convert.value(5).from("kilometer").to("mile");      // "3.11mi"
+convert.value(1).from("mile").to("kilometer");  
+convert.value(5).from("kilometer").to("mile");  
 ```
 
 ### Yards ↔ Meters
 
 ```ts
-convert.value(1).from("yard").to("meter");      // "0.914m"
-convert.value(50).from("meter").to("yard");     // "54.68yd"
+convert.value(1).from("yard").to("meter");  
+convert.value(50).from("meter").to("yard"); 
 ```
 
 ## Configuration Options
@@ -86,8 +86,8 @@ import { Conversion } from "@devhaven/unit-conversion";
 const convert = new Conversion({
   decimals: 4,       // set precision
   isFloat: true,     // keep decimals or round
-  includeUnit: true, // whether to append unit symbol
 });
 
-console.log(convert.value(1).from("mile").to("kilometer"));      // "1.6093km"
+const { value, unit } = convert.value(1).from("mile").to("kilometer");  
+console.log(value, unit); 
 ```

--- a/apps/docs/src/content/docs/conversions/length.mdx
+++ b/apps/docs/src/content/docs/conversions/length.mdx
@@ -9,8 +9,8 @@ This category is useful for engineering, construction, design, or any domain whe
 
 ## Supported Units
 
-- Metric: millimeter (mm), centimeter (cm), meter (m), kilometer (km)
-- Imperial / US: inch (in), foot (ft), yard (yd), mile (mi)
+- Metric: millimeter `mm`, centimeter `cm`, meter `m`, kilometer `km`
+- Imperial / US: inch `in`, foot `ft`, yard `yd`, mile `mi`
 
 ## Quick Example
 

--- a/apps/docs/src/content/docs/conversions/number.mdx
+++ b/apps/docs/src/content/docs/conversions/number.mdx
@@ -6,10 +6,10 @@ The **Number** category supports conversions between number bases such as binary
 
 ## Supported Bases
 
-- binary (base 2)
-- octal (base 8)
-- decimal (base 10)
-- hexadecimal (base 16)
+- binary `base 2`
+- octal `base 8`
+- decimal `base 10`
+- hexadecimal `base 16`
 
 
 ## Quick Example

--- a/apps/docs/src/content/docs/conversions/number.mdx
+++ b/apps/docs/src/content/docs/conversions/number.mdx
@@ -13,28 +13,32 @@ The **Number** category supports conversions between number bases such as binary
 
 
 ## Quick Example
-```ts
-console.log(convert.value(255).from("decimal").to("hexadecimal"));    // "ff"
 
-console.log(convert.value("1010").from("binary").to("decimal"));      // "10"
+```ts twoslash
+import { Conversion } from "@devhaven/unit-conversion";
+
+const convert = new Conversion();
+
+convert.value(255).from("decimal").to("hexadecimal")
+convert.value(1010).from("binary").to("decimal")
 ```
 
 ## Common Conversions
 
 ### Binary ↔ Decimal
 ```ts
-convert.value(10).from("decimal").to("binary");      // "1010"
-convert.value(10).from("binary").to("decimal");      // "1010"
+convert.value(10).from("decimal").to("binary");      
+convert.value(10).from("binary").to("decimal");      
 ```
 
 ### Decimal ↔ Hexadecimal
 ```ts
-convert.value("a").from("hexadecimal").to("decimal");     // "10"
-convert.value(15).from("decimal").to("hexadecimal");      // "f"
+convert.value("a").from("hexadecimal").to("decimal");     
+convert.value(15).from("decimal").to("hexadecimal");      
 ```
 
 ### Octal ↔ Decimal
 ```ts
-convert.value(77).from("octal").to("decimal");      // "63"
-convert.value(77).from("decimal").to("octal");      // "115"
+convert.value(77).from("octal").to("decimal");      
+convert.value(77).from("decimal").to("octal");      
 ```

--- a/apps/docs/src/content/docs/conversions/pressure.mdx
+++ b/apps/docs/src/content/docs/conversions/pressure.mdx
@@ -1,0 +1,45 @@
+---
+title: "Pressure"
+template: doc
+---
+
+The Pressure category supports conversions between Pascal, Kilopascal, Bar, PSI, and standard atmosphere.
+
+## Supported Units
+
+- Pascal (Pa)
+- Kilopascal (kPa)
+- Bar (bar)
+- PSI (psi)
+- Standard Atmosphere (atm)
+
+## Quick Example
+
+```ts
+import { Conversion } from "@devhaven/unit-conversion";
+
+const convert = new Conversion();
+
+convert.value(100).from("pascal").to("kilopascal");      
+convert.value(1).from("kilopascal").to("pascal");    
+```
+
+## Common Conversions
+
+### Pascal ↔ Bar
+```ts
+convert.value(1).from("pascal").to("bar");    
+convert.value(1).from("bar").to("pascal");      
+```
+
+### Kilopascal ↔ PSI
+```ts
+convert.value(1).from("kilopascal").to("psi");     
+convert.value(1).from("psi").to("kilopascal");      
+```
+
+### Bar ↔ PSI
+```ts
+convert.value(1).from("bar").to("psi");     
+convert.value(1).from("psi").to("bar");      
+```

--- a/apps/docs/src/content/docs/conversions/pressure.mdx
+++ b/apps/docs/src/content/docs/conversions/pressure.mdx
@@ -7,11 +7,11 @@ The Pressure category supports conversions between Pascal, Kilopascal, Bar, PSI,
 
 ## Supported Units
 
-- Pascal (Pa)
-- Kilopascal (kPa)
-- Bar (bar)
-- PSI (psi)
-- Standard Atmosphere (atm)
+- Pascal `Pa`
+- Kilopascal `kPa`
+- Bar `bar`
+- PSI `psi`
+- Standard Atmosphere `atm`
 
 ## Quick Example
 

--- a/apps/docs/src/content/docs/conversions/temperature.mdx
+++ b/apps/docs/src/content/docs/conversions/temperature.mdx
@@ -7,9 +7,9 @@ The Temperature category supports conversions between Celsius, Fahrenheit, and K
 
 ## Supported Units
 
-- celsius (°C)
-- fahrenheit (°F)
-- kelvin (K)
+- celsius `°C`
+- fahrenheit `°F`
+- kelvin `K`
 
 ## Quick Example
 

--- a/apps/docs/src/content/docs/conversions/temperature.mdx
+++ b/apps/docs/src/content/docs/conversions/temperature.mdx
@@ -14,9 +14,12 @@ The Temperature category supports conversions between Celsius, Fahrenheit, and K
 ## Quick Example
 
 ```ts
-console.log(convert.value(0).from("celsius").to("fahrenheit"));      // "32°F"
+import { Conversion } from "@devhaven/unit-conversion";
 
-console.log(convert.value(212).from("fahrenheit").to("celsius"));    // "100°C"
+const convert = new Conversion();
+
+convert.value(0).from("celsius").to("fahrenheit");      
+convert.value(212).from("fahrenheit").to("celsius");    
 ```
 
 ## Common Conversions
@@ -24,12 +27,12 @@ console.log(convert.value(212).from("fahrenheit").to("celsius"));    // "100°C"
 
 ### Celsius ↔ Kelvin
 ```ts
-convert.value(100).from("celsius").to("kelvin");    // "373.15K"
-convert.value(0).from("kelvin").to("celsius");      // "-273.15°C"
+convert.value(100).from("celsius").to("kelvin");    
+convert.value(0).from("kelvin").to("celsius");      
 ```
 
 ### Celsius ↔ Fahrenheit
 ```ts
-convert.value(100).from("celsius").to("fahrenheit");     // "212°F"
-convert.value(32).from("fahrenheit").to("celsius");      // "0°C"
+convert.value(100).from("celsius").to("fahrenheit");     
+convert.value(32).from("fahrenheit").to("celsius");      
 ```

--- a/apps/docs/src/content/docs/conversions/time.mdx
+++ b/apps/docs/src/content/docs/conversions/time.mdx
@@ -18,8 +18,9 @@ The **time** category provides conversions between milliseconds, seconds, minute
 import { Conversion } from "@devhaven/unit-conversion";
 
 const convert = new Conversion();
-console.log(convert.value(60000).from("millisecond").to("minute"));      // "1min"
-console.log(convert.value(2).from("hour").to("minute"));                 // "120min"
+
+convert.value(60000).from("millisecond").to("minute");      
+convert.value(2).from("hour").to("minute");                 
 ```
 
 ## Common Conversions
@@ -27,20 +28,20 @@ console.log(convert.value(2).from("hour").to("minute"));                 // "120
 ### Day ↔ Hour
 
 ```ts
-convert.value(1).from("day").to("hour");        // "24h"
-convert.value(24).from("hour").to("day");       // "1d"
+convert.value(1).from("day").to("hour");        
+convert.value(24).from("hour").to("day");       
 ```
 
 ### Second ↔ Hour
 
 ```ts
-convert.value(3600).from("second").to("hour");      // "1h"
-convert.value(1).from("hour").to("second");         // "3600s"
+convert.value(3600).from("second").to("hour");      
+convert.value(1).from("hour").to("second");         
 ```
 
 ### Millisecond ↔ Second
 
 ```ts
-convert.value(1000).from("millisecond").to("second");      // "1s"
-convert.value(1).from("second").to("millisecond");         // "1000ms"
+convert.value(1000).from("millisecond").to("second");      
+convert.value(1).from("second").to("millisecond");         
 ```

--- a/apps/docs/src/content/docs/conversions/time.mdx
+++ b/apps/docs/src/content/docs/conversions/time.mdx
@@ -6,11 +6,11 @@ The **time** category provides conversions between milliseconds, seconds, minute
 
 ## Supported Units
 
-- millisecond (ms)
-- second (s)
-- minute (min)
-- hour (h)
-- day (d)
+- millisecond `ms`
+- second `s`
+- minute `min`
+- hour `h`
+- day `d`
 
 ## Quick Example
 

--- a/apps/docs/src/content/docs/conversions/volume.mdx
+++ b/apps/docs/src/content/docs/conversions/volume.mdx
@@ -6,8 +6,8 @@ The Volume category converts between metric liters/milliliters and Imperial/US g
 
 ## Supported Units
 
-- Metric: milliliter (ml), liter (l)
-- Imperial / US: fluid ounce (fl oz), cup, pint (pt), quart (qt), gallon (gal)
+- Metric: milliliter `ml`, liter `l`
+- Imperial / US: fluid ounce `fl oz`, cup, pint `pt`, quart `qt`, gallon `gal`
 
 ## Quick Example
 ```ts

--- a/apps/docs/src/content/docs/conversions/volume.mdx
+++ b/apps/docs/src/content/docs/conversions/volume.mdx
@@ -11,29 +11,31 @@ The Volume category converts between metric liters/milliliters and Imperial/US g
 
 ## Quick Example
 ```ts
-console.log(convert.value(1000).from("milliliter").to("liter")); 
-// "1l"
+import { Conversion } from "@devhaven/unit-conversion";
 
-console.log(convert.value(1).from("gallon").to("liter")); 
-// "3.785l"
+const convert = new Conversion();
+
+convert.value(1000).from("milliliter").to("liter"); 
+convert.value(1).from("gallon").to("liter"); 
+
 ```
 
 ## Common Conversions
 
 ### Liter ↔ Milliliter
 ```ts
-convert.value(1).from("liter").to("milliliter");      // "1000ml"
-convert.value(1).from("milliliter").to("liter");      // "0.001l"
+convert.value(1).from("liter").to("milliliter");      
+convert.value(1).from("milliliter").to("liter");      
 ```
 
 ### Liter ↔ Cubic Meter
 ```ts
-convert.value(1).from("liter").to("cubic-meter");      // "0.001m^3"
-convert.value(1).from("cubic-meter").to("liter");      // "1000l"
+convert.value(1).from("liter").to("cubic-meter");      
+convert.value(1).from("cubic-meter").to("liter");      
 ```
 
 ### Cup (US) ↔ Milliliter
 ```ts
-convert.value(1).from("us-legal-cup").to("milliliter");      // "236.5882ml"
-convert.value(1).from("milliliter").to("us-legal-cup");      // "0.0042cup (US)"
+convert.value(1).from("us-legal-cup").to("milliliter");      
+convert.value(1).from("milliliter").to("us-legal-cup");      
 ```

--- a/apps/docs/src/content/docs/conversions/weight.mdx
+++ b/apps/docs/src/content/docs/conversions/weight.mdx
@@ -17,8 +17,8 @@ import { Conversion } from "@devhaven/unit-conversion";
 
 const convert = new Conversion();
 
-console.log(convert.value(1000).from("gram").to("kilogram"));    // "1kg"
-console.log(convert.value(1).from("pound").to("kilogram"));      // "0.454kg"
+convert.value(1000).from("gram").to("kilogram");    
+convert.value(1).from("pound").to("kilogram");      
 ```
 
 ## Common Conversions
@@ -26,13 +26,13 @@ console.log(convert.value(1).from("pound").to("kilogram"));      // "0.454kg"
 ### Gram ↔ Kilogram
 
 ```ts
-convert.value(1000).from("gram").to("kilogram");      // "1kg"
-convert.value(1).from("kilogram").to("gram");         // "1000g"
+convert.value(1000).from("gram").to("kilogram");      
+convert.value(1).from("kilogram").to("gram");         
 
 ```
 ### Ounce ↔ Pound
 
 ```ts
-convert.value(16).from("ounce").to("pound");      // "1lb"
-convert.value(1).from("pound").to("ounce");       // "16oz"
+convert.value(16).from("ounce").to("pound");      
+convert.value(1).from("pound").to("ounce");       
 ```

--- a/apps/docs/src/content/docs/conversions/weight.mdx
+++ b/apps/docs/src/content/docs/conversions/weight.mdx
@@ -7,8 +7,8 @@ The **weight** category provides conversions between metric units (grams, kilogr
 
 ## Supported Units
 
-- Metric: milligram (mg), gram (g), kilogram (kg), tonne (t)
-- Imperial / US: ounce (oz), pound (lb), stone (st), ton (US ton)
+- Metric: milligram `mg`, gram `g`, kilogram `kg`, tonne `t`
+- Imperial / US: ounce `oz`, pound `lb`, stone `st`, ton `US ton`
 
 ## Quick Example
 

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -14,10 +14,7 @@ import { Conversion } from "@devhaven/unit-conversion";
 const convert = new Conversion();
 
 // Convert 100 meters → kilometers
-console.log(convert.value(100).from("meter").to("kilometer"));
-// "0.1km"
-
-// Convert 1 inch → centimeters
-console.log(convert.value(1).from("inch").to("centimeter"));
-// "2.54cm"
+const { value, unit } = convert.value(100).from("meter").to("kilometer");
+console.log(value, unit);
+// 0.1, "km"
 ```

--- a/apps/docs/src/content/docs/installation.mdx
+++ b/apps/docs/src/content/docs/installation.mdx
@@ -10,7 +10,6 @@ import { Code } from '@astrojs/starlight/components'
 
 You can install `@devhaven/unit-conversion` from [npm](https://www.npmjs.com/package/@devhaven/unit-conversion):
 
-
 <PackageManagers
   pkg="@devhaven/unit-conversion"
   pkgManagers={["npm", "yarn", "pnpm", "bun"]}

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@devhaven/unit-conversion": ["../../packages/unit-conversion/src/index.ts"]
+    }
+  }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/starlight": "^0.35.2",
-        "@devhaven/unit-conversion": "0.0.6",
+        "@devhaven/unit-conversion": "workspace:*",
         "astro": "^5.6.1",
         "expressive-code-twoslash": "0.5.3",
         "sharp": "^0.34.2",
@@ -1290,8 +1290,6 @@
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "docs/@devhaven/unit-conversion": ["@devhaven/unit-conversion@0.0.6", "", {}, "sha512-2IU5/YS7wuRuTn2sAJqa5K9pHw34UzxasWSmC1lm8DC5TIJpZ90WB6HzXpfZc6/OdYNJBt3tHPKbU1aeE1Y4VA=="],
 
     "hast-util-to-parse5/property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
 

--- a/packages/unit-conversion/README.md
+++ b/packages/unit-conversion/README.md
@@ -39,5 +39,5 @@ deno add jsr:@devhaven/unit-conversion
 import { Conversion } from "@devhaven/unit-conversion"
 
 const conversion = new Conversion();
-const result = conversion.value(10).from("meter").to("foot");
+const { value, unit } = conversion.value(10).from("meter").to("foot");
 ```

--- a/packages/unit-conversion/jsr.jsonc
+++ b/packages/unit-conversion/jsr.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@devhaven/unit-conversion",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "exports": "./src/index.ts",
   "license": "Apache-2.0",
   "publish": {

--- a/packages/unit-conversion/package.json
+++ b/packages/unit-conversion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devhaven/unit-conversion",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "A type-safe unit conversion library.",
   "license": "Apache-2.0",
   "author": "Ram Shankar Choudhary",

--- a/packages/unit-conversion/src/constants/config.ts
+++ b/packages/unit-conversion/src/constants/config.ts
@@ -1,6 +1,5 @@
 export interface ConversionConfig {
   isFloat?: boolean;
-  includeUnit?: boolean;
   decimals?: number;
 }
 
@@ -8,10 +7,9 @@ export interface ConversionConfig {
  * Default configuration for unit conversions.
  * @type {ConversionConfig}
  * @property {boolean} isFloat - Whether the conversion result should be a floating-point number. Default is true.
- * @property {boolean} includeUnit - Whether to include the unit symbol in the conversion output. Default is true.
- * @property {number} decimals - Number of decimal places to round the conversion result to. Default is 20.
+ * @property {number} decimals - Number of decimal places to round the conversion result to. Default is 2.
  */
 export const DEFAULT_CONFIG: ConversionConfig = {
   isFloat: true,
-  decimals: 20,
+  decimals: 2,
 };

--- a/packages/unit-conversion/src/constants/config.ts
+++ b/packages/unit-conversion/src/constants/config.ts
@@ -9,10 +9,9 @@ export interface ConversionConfig {
  * @type {ConversionConfig}
  * @property {boolean} isFloat - Whether the conversion result should be a floating-point number. Default is true.
  * @property {boolean} includeUnit - Whether to include the unit symbol in the conversion output. Default is true.
- * @property {number} decimals - Number of decimal places to round the conversion result to. Default is 2.
+ * @property {number} decimals - Number of decimal places to round the conversion result to. Default is 20.
  */
 export const DEFAULT_CONFIG: ConversionConfig = {
   isFloat: true,
-  includeUnit: true,
-  decimals: 2,
+  decimals: 20,
 };

--- a/packages/unit-conversion/src/constants/labels.ts
+++ b/packages/unit-conversion/src/constants/labels.ts
@@ -104,7 +104,6 @@ export const LABELS = {
   farad: "F",
   henry: "H",
   hertz: "Hz",
-  joule: "J",
 
   // thermodynamic temperature
   kelvin: "K",
@@ -119,4 +118,21 @@ export const LABELS = {
   // luminous intensity
   candela: "cd",
   stilb: "sb",
+
+  // pressure
+  pascal: "Pa",
+  kilopascal: "kPa",
+  bar: "bar",
+  psi: "psi",
+  atmosphere: "atm",
+
+  // energy
+  joule: "J",
+  kilojoule: "kJ",
+  calorie: "cal",
+  "calorie-international-table": "cal (IT)",
+  "calorie-thermochemical": "cal (th)",
+  "watt-hour": "Wh",
+  "kilowatt-hour": "kWh",
+  "electron-volt": "eV",
 } as const;

--- a/packages/unit-conversion/src/constants/units.ts
+++ b/packages/unit-conversion/src/constants/units.ts
@@ -2,7 +2,6 @@ export type TemperatureUnits = "celsius" | "fahrenheit" | "kelvin";
 
 export type LengthUnits = "meter" | "kilometer" | "centimeter" | "millimeter" | "inch" | "foot" | "yard" | "mile";
 export type WeightUnits = "milligram" | "gram" | "kilogram" | "pound" | "ounce" | "ton";
-
 export type VolumeUnits =
   | "liter"
   | "milliliter"
@@ -15,12 +14,30 @@ export type VolumeUnits =
   | "cubic-meter"
   | "cubic-foot"
   | "cubic-inch";
-
 export type TimeUnits = "millisecond" | "second" | "minute" | "hour" | "day" | "week" | "month" | "year";
-
 export type NumberUnits = "binary" | "decimal" | "hexadecimal" | "base8";
+export type PressureUnits = "pascal" | "kilopascal" | "bar" | "psi" | "atmosphere";
+export type EnergyUnits =
+  | "joule"
+  | "kilojoule"
+  | "calorie"
+  | "calorie-international-table"
+  | "calorie-thermochemical"
+  | "watt-hour"
+  | "kilowatt-hour"
+  | "electron-volt";
+export type AngleUnits = "radian" | "degree" | "gradian" | "arcminute" | "arcsecond";
 
-export type AllUnits = TemperatureUnits | LengthUnits | WeightUnits | VolumeUnits | TimeUnits | NumberUnits;
+export type AllUnits =
+  | TemperatureUnits
+  | LengthUnits
+  | WeightUnits
+  | VolumeUnits
+  | TimeUnits
+  | NumberUnits
+  | PressureUnits
+  | EnergyUnits
+  | AngleUnits;
 
 export type UnitCategory<T extends AllUnits> = T extends TemperatureUnits
   ? TemperatureUnits
@@ -34,7 +51,13 @@ export type UnitCategory<T extends AllUnits> = T extends TemperatureUnits
           ? TimeUnits
           : T extends NumberUnits
             ? NumberUnits
-            : never;
+            : T extends PressureUnits
+              ? PressureUnits
+              : T extends EnergyUnits
+                ? EnergyUnits
+                : T extends AngleUnits
+                  ? AngleUnits
+                  : never;
 
 export type ALL_UNIT_CATEGORIES = {
   temperature: TemperatureUnits[];
@@ -43,6 +66,9 @@ export type ALL_UNIT_CATEGORIES = {
   volume: VolumeUnits[];
   time: TimeUnits[];
   number: NumberUnits[];
+  pressure: PressureUnits[];
+  energy: EnergyUnits[];
+  angle: AngleUnits[];
 };
 
 /**
@@ -51,11 +77,15 @@ export type ALL_UNIT_CATEGORIES = {
  * @description
  * This module exports a collection of units organized by measurement category.
  *
- * @property {string[]} temperature - Units for temperature measurements (celsius, fahrenheit, kelvin)
- * @property {string[]} length - Units for length measurements (meter, kilometer, centimeter, millimeter, inch, foot, yard, mile)
- * @property {string[]} weight - Units for weight measurements (gram, kilogram, pound, ounce, ton)
- * @property {string[]} volume - Units for volume measurements (liter, milliliter, gallon, quart, pint, cup, fluid-ounce)
- * @property {string[]} time - Units for time measurements (second, minute, hour, day, week, month, year)
+ * @property {string[]} temperature - Units for temperature measurements. Base unit is kelvin
+ * @property {string[]} length - Units for length measurements. Base unit is meter
+ * @property {string[]} weight - Units for weight measurements. Base unit is gram
+ * @property {string[]} volume - Units for volume measurements. Base unit is liter
+ * @property {string[]} time - Units for time measurements. Base unit is second
+ * @property {string[]} number - Units for number measurements. Base unit is base-10
+ * @property {string[]} pressure - Units for pressure measurements. Base unit is pascal
+ * @property {string[]} energy - Units for energy measurements. Base unit is joule
+ * @property {string[]} angle - Units for angle measurements. Base unit is radian
  */
 export const UNITS: ALL_UNIT_CATEGORIES = {
   temperature: ["celsius", "fahrenheit", "kelvin"],
@@ -76,6 +106,18 @@ export const UNITS: ALL_UNIT_CATEGORIES = {
   ],
   time: ["millisecond", "second", "minute", "hour", "day", "week", "month", "year"],
   number: ["decimal", "binary", "hexadecimal", "base8"],
+  pressure: ["pascal", "kilopascal", "bar", "psi", "atmosphere"],
+  energy: [
+    "joule",
+    "kilojoule",
+    "calorie",
+    "calorie-international-table",
+    "calorie-thermochemical",
+    "watt-hour",
+    "kilowatt-hour",
+    "electron-volt",
+  ],
+  angle: ["degree", "radian", "gradian", "arcminute", "arcsecond"],
 };
 
 export const NO_UNITS_CATEGORIES = ["number"];

--- a/packages/unit-conversion/src/main.ts
+++ b/packages/unit-conversion/src/main.ts
@@ -4,7 +4,7 @@ import type { AllUnits, UnitCategory } from "./constants/units";
 import { getUnitCategory } from "./utils/common";
 import { CONVERSION_FACTORS, type ConversionFactor } from "./utils/conversion-factors";
 
-type InputValue = number | string;
+type UnitType = number | string;
 
 /**
  * Represents a value with conversion capabilities.
@@ -21,7 +21,7 @@ type InputValue = number | string;
  * const length = new ValueWithFrom(5, config).from('m').to('ft');
  * ```
  */
-class ValueWithFrom<T extends InputValue> {
+class ValueWithFrom<T extends UnitType> {
   constructor(
     private val: T,
     private config: ConversionConfig,
@@ -45,7 +45,7 @@ class ValueWithFrom<T extends InputValue> {
  * const inMiles = distance.to('mi'); // Returns { value: 62.14, unit: 'mi' }
  * ```
  */
-class FromUnit<T extends InputValue, F extends AllUnits> {
+class FromUnit<T extends UnitType, F extends AllUnits> {
   constructor(
     private value: T,
     private fromUnit: F,
@@ -66,14 +66,14 @@ class FromUnit<T extends InputValue, F extends AllUnits> {
     // Handle type conversion properly based on input type
     let baseValue: number | string;
     if (typeof this.value === "number") {
-      baseValue = (fromUnitFactors.toBase as (v: number) => InputValue)(this.value);
+      baseValue = (fromUnitFactors.toBase as (v: number) => UnitType)(this.value);
     } else {
       // Convert string to number for calculations
       const numericValue = parseFloat(this.value as string);
       if (Number.isNaN(numericValue)) {
         throw new Error(`Invalid numeric value: ${this.value}`);
       }
-      baseValue = (fromUnitFactors.toBase as (v: number) => InputValue)(numericValue);
+      baseValue = (fromUnitFactors.toBase as (v: number) => UnitType)(numericValue);
     }
 
     // Convert baseValue to number if it's a string for the final conversion
@@ -82,7 +82,7 @@ class FromUnit<T extends InputValue, F extends AllUnits> {
       throw new Error(`Invalid base value after conversion: ${baseValue}`);
     }
 
-    const numericResult = (toUnitFactors.fromBase as (v: number) => InputValue)(baseNumeric);
+    const numericResult = (toUnitFactors.fromBase as (v: number) => UnitType)(baseNumeric);
 
     let finalValue = numericResult;
     if (typeof numericResult === "number") {

--- a/packages/unit-conversion/src/main.ts
+++ b/packages/unit-conversion/src/main.ts
@@ -1,6 +1,6 @@
 import { type ConversionConfig, DEFAULT_CONFIG } from "./constants/config";
 import { LABELS } from "./constants/labels";
-import { type AllUnits, NO_UNITS_CATEGORIES, type UnitCategory } from "./constants/units";
+import type { AllUnits, UnitCategory } from "./constants/units";
 import { getUnitCategory } from "./utils/common";
 import { CONVERSION_FACTORS, type ConversionFactor } from "./utils/conversion-factors";
 
@@ -41,8 +41,8 @@ class ValueWithFrom<T extends InputValue> {
  * @example
  * ```ts
  * // Convert 100 kilometers to miles
- * const distance = new FromUnit(100, 'km', { decimals: 2, includeUnit: true });
- * const inMiles = distance.to('mi'); // Returns "62.14mi"
+ * const distance = new FromUnit(100, 'km', { decimals: 2 });
+ * const inMiles = distance.to('mi'); // Returns { value: 62.14, unit: 'mi' }
  * ```
  */
 class FromUnit<T extends InputValue, F extends AllUnits> {
@@ -52,7 +52,7 @@ class FromUnit<T extends InputValue, F extends AllUnits> {
     private config: ConversionConfig,
   ) {}
 
-  to<U extends UnitCategory<F>>(unit: U): InputValue {
+  to<U extends UnitCategory<F>>(unit: U) {
     const category = getUnitCategory(this.fromUnit);
     const categoryFactors = CONVERSION_FACTORS[category];
 
@@ -89,19 +89,15 @@ class FromUnit<T extends InputValue, F extends AllUnits> {
       finalValue =
         this.config.isFloat === false
           ? Math.round(numericResult)
-          : Number(numericResult.toFixed(this.config.decimals ?? 2));
+          : Number(numericResult.toFixed(this.config.decimals ?? 20));
     }
 
-    // Return with unit label if includeUnit is true (default)
-    if (this.config.includeUnit !== false) {
-      const unitLabel = LABELS[unit as keyof typeof LABELS] || unit;
-      if (NO_UNITS_CATEGORIES.includes(category.toString())) {
-        return finalValue;
-      }
-      return `${finalValue}${unitLabel}`;
-    }
+    const unitLabel = LABELS[unit as keyof typeof LABELS] || unit;
 
-    return finalValue;
+    return {
+      value: finalValue,
+      unit: unitLabel,
+    };
   }
 }
 

--- a/packages/unit-conversion/src/utils/common.ts
+++ b/packages/unit-conversion/src/utils/common.ts
@@ -27,6 +27,9 @@ export function getUnitCategory(unit: AllUnits): keyof typeof CONVERSION_FACTORS
   if (isUnitInCategory(unit, "volume")) return "volume";
   if (isUnitInCategory(unit, "time")) return "time";
   if (isUnitInCategory(unit, "number")) return "number";
+  if (isUnitInCategory(unit, "pressure")) return "pressure";
+  if (isUnitInCategory(unit, "energy")) return "energy";
+  if (isUnitInCategory(unit, "angle")) return "angle";
 
   throw new Error(`Unknown unit: ${unit}`);
 }

--- a/packages/unit-conversion/src/utils/conversion-factors.ts
+++ b/packages/unit-conversion/src/utils/conversion-factors.ts
@@ -339,4 +339,52 @@ export const CONVERSION_FACTORS: ConversionFactorGroups = {
       },
     },
   },
+
+  // Pressure (base: pascal)
+  pressure: {
+    pascal: {
+      isBaseUnit: true,
+      toBase: (v: number) => v,
+      fromBase: (v: number) => v,
+    },
+    kilopascal: {
+      isBaseUnit: true,
+      toBase: (v: number) => v * 1000,
+      fromBase: (v: number) => v / 1000,
+    },
+    bar: {
+      toBase: (v: number) => v * 100_000,
+      fromBase: (v: number) => v / 100_000,
+    },
+    psi: {
+      toBase: (v: number) => v * 6894.76,
+      fromBase: (v: number) => v / 6894.76,
+    },
+    atmosphere: {
+      toBase: (v: number) => v * 101325,
+      fromBase: (v: number) => v / 101325,
+    },
+  },
+
+  // Energy (base: joule)
+  energy: {
+    joule: { toBase: (v: number) => v, fromBase: (v: number) => v },
+    kilojoule: { toBase: (v: number) => v * 1000, fromBase: (v: number) => v / 1000 },
+    calorie: { toBase: (v: number) => v / 0.0002388459, fromBase: (v: number) => v * 0.0002388459 },
+    "calorie-international-table": {
+      toBase: (v: number) => v / 0.2388458966,
+      fromBase: (v: number) => v * 0.2388458966,
+    },
+    "calorie-thermochemical": { toBase: (v: number) => v / 0.2390057361, fromBase: (v: number) => v * 0.2390057361 },
+    "watt-hour": { toBase: (v: number) => v / 0.0002777778, fromBase: (v: number) => v * 0.0002777778 },
+    "kilowatt-hour": {
+      toBase: (v: number) => v / (2.777777777 * 10 ** -7),
+      fromBase: (v: number) => v * (2.777777777 * 10 ** -7),
+    },
+    "electron-volt": {
+      toBase: (v: number) => v / 6241509074461000000,
+      fromBase: (v: number) => v * 6241509074461000000,
+    },
+  },
+  // Angle (base: radian)
 };

--- a/packages/unit-conversion/tests/conversion.spec.ts
+++ b/packages/unit-conversion/tests/conversion.spec.ts
@@ -7,110 +7,144 @@ type TestValues = {
   from: AllUnits;
   to: AllUnits;
   expected: number | string;
+  unit?: string;
 };
 
+/**
+ * Determines if two numbers are approximately equal within a relative tolerance.
+ *
+ * @param a - First number to compare
+ * @param b - Second number to compare
+ * @param relativeTolerance - Relative tolerance for comparison (default: 1e-2 or 1%)
+ * @returns Boolean indicating if the numbers are approximately equal
+ *
+ * @remarks
+ * This function uses relative tolerance rather than absolute difference, making it suitable
+ * for comparing numbers of different magnitudes. The comparison is considered valid when:
+ * |a - b| ≤ max(|a|, |b|, 1) × relativeTolerance
+ *
+ * @example
+ * // Returns true (within 1% tolerance)
+ * isApproximatelyEqual(100, 101);
+ *
+ * @example
+ * // Using custom tolerance (0.1%)
+ * isApproximatelyEqual(100, 100.05, 0.001); // true
+ */
+function isApproximatelyEqual(a: number, b: number, relativeTolerance: number = 1e-2): boolean {
+  const diff = Math.abs(a - b);
+  const largest = Math.max(Math.abs(a), Math.abs(b), 1);
+  return diff <= largest * relativeTolerance;
+}
+
 test("Check conversion config", () => {
-  const withUnit = new Conversion({
-    isFloat: false,
-    includeUnit: true,
-  });
-  const withoutUnit = new Conversion({
-    isFloat: false,
-    includeUnit: false,
+  const withFloat = new Conversion({
+    isFloat: true,
   });
 
-  expect(withUnit.value(12).from("celsius").to("kelvin")).toBe("285K");
-  expect(withoutUnit.value(12).from("celsius").to("kelvin")).toBe(285);
+  const resultWithFloat = withFloat.value(12).from("celsius").to("kelvin");
+
+  const withoutFloat = new Conversion({
+    isFloat: false,
+  });
+
+  const resultWithoutFloat = withoutFloat.value(12).from("celsius").to("kelvin");
+
+  expect(isApproximatelyEqual(+resultWithFloat.value, 285)).toBe(true);
+  expect(isApproximatelyEqual(+resultWithoutFloat.value, 285)).toBe(true);
 });
 
 describe("Test Length conversions", () => {
   const lengthTests: Array<TestValues> = [
-    { value: 1, from: "meter", to: "millimeter", expected: "1000mm" },
-    { value: 1, from: "meter", to: "centimeter", expected: "100cm" },
-    { value: 1, from: "meter", to: "inch", expected: "39.37in" },
-    { value: 1, from: "meter", to: "foot", expected: "3.28ft" },
-    { value: 1, from: "meter", to: "kilometer", expected: "0km" },
-    { value: 1, from: "meter", to: "mile", expected: "0mi" },
-    { value: 1, from: "meter", to: "yard", expected: "1.09yd" },
-    { value: 1, from: "kilometer", to: "millimeter", expected: "1000000mm" },
-    { value: 1, from: "kilometer", to: "centimeter", expected: "100000cm" },
-    { value: 1, from: "kilometer", to: "inch", expected: "39370.08in" },
-    { value: 1, from: "kilometer", to: "foot", expected: "3280.84ft" },
-    { value: 1, from: "kilometer", to: "meter", expected: "1000m" },
-    { value: 1, from: "kilometer", to: "mile", expected: "0.62mi" },
-    { value: 1, from: "kilometer", to: "yard", expected: "1093.61yd" },
-    { value: 1, from: "centimeter", to: "millimeter", expected: "10mm" },
-    { value: 1, from: "centimeter", to: "kilometer", expected: "0km" },
-    { value: 1, from: "centimeter", to: "inch", expected: "0.39in" },
-    { value: 1, from: "centimeter", to: "foot", expected: "0.03ft" },
-    { value: 1, from: "centimeter", to: "meter", expected: "0.01m" },
-    { value: 1, from: "centimeter", to: "mile", expected: "0mi" },
-    { value: 1, from: "centimeter", to: "yard", expected: "0.01yd" },
-    { value: 1, from: "millimeter", to: "kilometer", expected: "0km" },
-    { value: 1, from: "millimeter", to: "centimeter", expected: "0.1cm" },
-    { value: 1, from: "millimeter", to: "inch", expected: "0.04in" },
-    { value: 1, from: "millimeter", to: "foot", expected: "0ft" },
-    { value: 1, from: "millimeter", to: "meter", expected: "0m" },
-    { value: 1, from: "millimeter", to: "mile", expected: "0mi" },
-    { value: 1, from: "millimeter", to: "yard", expected: "0yd" },
-    { value: 1, from: "inch", to: "millimeter", expected: "25.4mm" },
-    { value: 1, from: "inch", to: "centimeter", expected: "2.54cm" },
-    { value: 1, from: "inch", to: "kilometer", expected: "0km" },
-    { value: 1, from: "inch", to: "foot", expected: "0.08ft" },
-    { value: 1, from: "inch", to: "meter", expected: "0.03m" },
-    { value: 1, from: "inch", to: "mile", expected: "0mi" },
-    { value: 1, from: "inch", to: "yard", expected: "0.03yd" },
+    { value: 1, from: "meter", to: "millimeter", expected: 1000, unit: "mm" },
+    { value: 1, from: "meter", to: "centimeter", expected: 100, unit: "cm" },
+    { value: 1, from: "meter", to: "inch", expected: 39.37, unit: "in" },
+    { value: 1, from: "meter", to: "foot", expected: 3.28, unit: "ft" },
+    { value: 1, from: "meter", to: "kilometer", expected: 0, unit: "km" },
+    { value: 1, from: "meter", to: "mile", expected: 0, unit: "mi" },
+    { value: 1, from: "meter", to: "yard", expected: 1.09, unit: "yd" },
+    { value: 1, from: "kilometer", to: "millimeter", expected: 1000000, unit: "mm" },
+    { value: 1, from: "kilometer", to: "centimeter", expected: 100000, unit: "cm" },
+    { value: 1, from: "kilometer", to: "inch", expected: 39370.08, unit: "in" },
+    { value: 1, from: "kilometer", to: "foot", expected: 3280.84, unit: "ft" },
+    { value: 1, from: "kilometer", to: "meter", expected: 1000, unit: "m" },
+    { value: 1, from: "kilometer", to: "mile", expected: 0.62, unit: "mi" },
+    { value: 1, from: "kilometer", to: "yard", expected: 1093.61, unit: "yd" },
+    { value: 1, from: "centimeter", to: "millimeter", expected: 10, unit: "mm" },
+    { value: 1, from: "centimeter", to: "kilometer", expected: 0, unit: "km" },
+    { value: 1, from: "centimeter", to: "inch", expected: 0.39, unit: "in" },
+    { value: 1, from: "centimeter", to: "foot", expected: 0.03, unit: "ft" },
+    { value: 1, from: "centimeter", to: "meter", expected: 0.0, unit: "1m" },
+    { value: 1, from: "centimeter", to: "mile", expected: 0, unit: "mi" },
+    { value: 1, from: "centimeter", to: "yard", expected: 0.01, unit: "yd" },
+    { value: 1, from: "millimeter", to: "kilometer", expected: 0, unit: "km" },
+    { value: 1, from: "millimeter", to: "centimeter", expected: 0.1, unit: "cm" },
+    { value: 1, from: "millimeter", to: "inch", expected: 0.04, unit: "in" },
+    { value: 1, from: "millimeter", to: "foot", expected: 0, unit: "ft" },
+    { value: 1, from: "millimeter", to: "meter", expected: 0, unit: "m" },
+    { value: 1, from: "millimeter", to: "mile", expected: 0, unit: "mi" },
+    { value: 1, from: "millimeter", to: "yard", expected: 0, unit: "yd" },
+    { value: 1, from: "inch", to: "millimeter", expected: 25.4, unit: "mm" },
+    { value: 1, from: "inch", to: "centimeter", expected: 2.54, unit: "cm" },
+    { value: 1, from: "inch", to: "kilometer", expected: 0, unit: "km" },
+    { value: 1, from: "inch", to: "foot", expected: 0.08, unit: "ft" },
+    { value: 1, from: "inch", to: "meter", expected: 0.03, unit: "m" },
+    { value: 1, from: "inch", to: "mile", expected: 0, unit: "mi" },
+    { value: 1, from: "inch", to: "yard", expected: 0.03, unit: "yd" },
   ];
   const convert = new Conversion();
 
   lengthTests.forEach(({ value, from, to, expected }) => {
     test(`Converts ${value} ${from} to ${to}`, () => {
-      expect(convert.value(value).from(from).to(to)).toBe(expected);
+      const result = convert.value(value).from(from).to(to);
+      // expect(+result.value).toBe(+expected);
+      expect(isApproximatelyEqual(+result.value, +expected)).toBe(true);
     });
   });
 });
 
 describe("Test temperature conversions", () => {
   const temperatureTests: Array<TestValues> = [
-    { value: 1, from: "celsius", to: "kelvin", expected: "274.15K" },
-    { value: 1, from: "celsius", to: "fahrenheit", expected: "33.8°F" },
-    { value: 1, from: "kelvin", to: "celsius", expected: "-272.15°C" },
-    { value: 1, from: "kelvin", to: "fahrenheit", expected: "-457.87°F" },
-    { value: 1, from: "fahrenheit", to: "celsius", expected: "-17.22°C" },
-    { value: 1, from: "fahrenheit", to: "kelvin", expected: "255.93K" },
+    { value: 1, from: "celsius", to: "kelvin", expected: 274.15, unit: "K" },
+    { value: 1, from: "celsius", to: "fahrenheit", expected: 33.8, unit: "°F" },
+    { value: 1, from: "kelvin", to: "celsius", expected: -272.15, unit: "°C" },
+    { value: 1, from: "kelvin", to: "fahrenheit", expected: -457.87, unit: "°F" },
+    { value: 1, from: "fahrenheit", to: "celsius", expected: -17.22, unit: "°C" },
+    { value: 1, from: "fahrenheit", to: "kelvin", expected: 255.93, unit: "K" },
   ];
   const convert = new Conversion();
 
   temperatureTests.forEach(({ value, from, to, expected }) => {
     test(`Converts ${value} ${from} to ${to}`, () => {
-      expect(convert.value(value).from(from).to(to)).toBe(expected);
+      const result = convert.value(value).from(from).to(to);
+      expect(isApproximatelyEqual(+result.value, +expected)).toBe(true);
     });
   });
 });
 
 describe("Test weight conversions", () => {
   const weightTests: Array<TestValues> = [
-    { value: 1, from: "gram", to: "kilogram", expected: "0.001kg" },
-    { value: 1, from: "gram", to: "pound", expected: "0.0022lb" },
-    { value: 1, from: "gram", to: "ounce", expected: "0.0353oz" },
-    { value: 1, from: "gram", to: "ton", expected: "0ton" },
-    { value: 1, from: "gram", to: "milligram", expected: "1000mg" },
-    { value: 1, from: "kilogram", to: "gram", expected: "1000g" },
-    { value: 1, from: "kilogram", to: "pound", expected: "2.2046lb" },
-    { value: 1, from: "kilogram", to: "ounce", expected: "35.274oz" },
-    { value: 1, from: "kilogram", to: "ton", expected: "0.001ton" },
-    { value: 1, from: "pound", to: "kilogram", expected: "0.4536kg" },
-    { value: 1, from: "pound", to: "gram", expected: "453.592g" },
-    { value: 1, from: "pound", to: "ounce", expected: "16oz" },
-    { value: 1, from: "pound", to: "ton", expected: "0.0005ton" },
-    { value: 1, from: "ounce", to: "kilogram", expected: "0.0283kg" },
-    { value: 1, from: "ounce", to: "pound", expected: "0.0625lb" },
-    { value: 1, from: "ounce", to: "gram", expected: "28.3495g" },
-    { value: 1, from: "ounce", to: "ton", expected: "0ton" },
-    { value: 1, from: "ton", to: "kilogram", expected: "1000kg" },
-    { value: 1, from: "ton", to: "pound", expected: "2204.6244lb" },
-    { value: 1, from: "ton", to: "ounce", expected: "35273.9907oz" },
-    { value: 1, from: "ton", to: "gram", expected: "1000000g" },
+    { value: 1, from: "gram", to: "kilogram", expected: 0.001, unit: "kg" },
+    { value: 1, from: "gram", to: "pound", expected: 0.0022, unit: "lb" },
+    { value: 1, from: "gram", to: "ounce", expected: 0.0353, unit: "oz" },
+    { value: 1, from: "gram", to: "ton", expected: 0, unit: "ton" },
+    { value: 1, from: "gram", to: "milligram", expected: 1000, unit: "mg" },
+    { value: 1, from: "kilogram", to: "gram", expected: 1000, unit: "g" },
+    { value: 1, from: "kilogram", to: "pound", expected: 2.2046, unit: "lb" },
+    { value: 1, from: "kilogram", to: "ounce", expected: 35.274, unit: "oz" },
+    { value: 1, from: "kilogram", to: "ton", expected: 0.001, unit: "ton" },
+    { value: 1, from: "pound", to: "kilogram", expected: 0.4536, unit: "kg" },
+    { value: 1, from: "pound", to: "gram", expected: 453.592, unit: "g" },
+    { value: 1, from: "pound", to: "ounce", expected: 16, unit: "oz" },
+    { value: 1, from: "pound", to: "ton", expected: 0.0005, unit: "ton" },
+    { value: 1, from: "ounce", to: "kilogram", expected: 0.0283, unit: "kg" },
+    { value: 1, from: "ounce", to: "pound", expected: 0.0625, unit: "lb" },
+    { value: 1, from: "ounce", to: "gram", expected: 28.3495, unit: "g" },
+    { value: 1, from: "ounce", to: "ton", expected: 0, unit: "ton" },
+    { value: 1, from: "ton", to: "kilogram", expected: 1000, unit: "kg" },
+    { value: 1, from: "ton", to: "pound", expected: 2204.6244, unit: "lb" },
+    { value: 1, from: "ton", to: "ounce", expected: 35273.9907, unit: "oz" },
+    { value: 1, from: "ton", to: "gram", expected: 1000000, unit: "g" },
   ];
   const convert = new Conversion({
     decimals: 4,
@@ -118,43 +152,44 @@ describe("Test weight conversions", () => {
 
   weightTests.forEach(({ value, from, to, expected }) => {
     test(`Converts ${value} ${from} to ${to}`, () => {
-      expect(convert.value(value).from(from).to(to)).toBe(expected);
+      const result = convert.value(value).from(from).to(to);
+      expect(isApproximatelyEqual(+result.value, +expected)).toBe(true);
     });
   });
 });
 
 describe("Test time conversions", () => {
   const timeTests: Array<TestValues> = [
-    { value: 1, from: "millisecond", to: "second", expected: "0.001s" },
-    { value: 1, from: "millisecond", to: "minute", expected: "0min" },
-    { value: 1, from: "millisecond", to: "hour", expected: "0h" },
-    { value: 1, from: "millisecond", to: "day", expected: "0d" },
-    { value: 1, from: "millisecond", to: "week", expected: "0wk" },
-    { value: 1, from: "second", to: "millisecond", expected: "1000ms" },
-    { value: 1, from: "second", to: "minute", expected: "0.0167min" },
-    { value: 1, from: "second", to: "hour", expected: "0.0003h" },
-    { value: 1, from: "second", to: "day", expected: "0d" },
-    { value: 1, from: "second", to: "week", expected: "0wk" },
-    { value: 1, from: "minute", to: "millisecond", expected: "60000ms" },
-    { value: 1, from: "minute", to: "second", expected: "60s" },
-    { value: 1, from: "minute", to: "hour", expected: "0.0167h" },
-    { value: 1, from: "minute", to: "day", expected: "0.0007d" },
-    { value: 1, from: "minute", to: "week", expected: "0.0001wk" },
-    { value: 1, from: "hour", to: "millisecond", expected: "3600000ms" },
-    { value: 1, from: "hour", to: "minute", expected: "60min" },
-    { value: 1, from: "hour", to: "second", expected: "3600s" },
-    { value: 1, from: "hour", to: "day", expected: "0.0417d" },
-    { value: 1, from: "hour", to: "week", expected: "0.006wk" },
-    { value: 1, from: "day", to: "millisecond", expected: "86400000ms" },
-    { value: 1, from: "day", to: "minute", expected: "1440min" },
-    { value: 1, from: "day", to: "hour", expected: "24h" },
-    { value: 1, from: "day", to: "second", expected: "86400s" },
-    { value: 1, from: "day", to: "week", expected: "0.1429wk" },
-    { value: 1, from: "week", to: "millisecond", expected: "604800000ms" },
-    { value: 1, from: "week", to: "minute", expected: "10080min" },
-    { value: 1, from: "week", to: "hour", expected: "168h" },
-    { value: 1, from: "week", to: "second", expected: "604800s" },
-    { value: 1, from: "week", to: "day", expected: "7d" },
+    { value: 1, from: "millisecond", to: "second", expected: 0.0, unit: "1s" },
+    { value: 1, from: "millisecond", to: "minute", expected: 0, unit: "min" },
+    { value: 1, from: "millisecond", to: "hour", expected: 0, unit: "h" },
+    { value: 1, from: "millisecond", to: "day", expected: 0, unit: "d" },
+    { value: 1, from: "millisecond", to: "week", expected: 0, unit: "wk" },
+    { value: 1, from: "second", to: "millisecond", expected: 1000, unit: "ms" },
+    { value: 1, from: "second", to: "minute", expected: 0.0167, unit: "min" },
+    { value: 1, from: "second", to: "hour", expected: 0.0003, unit: "h" },
+    { value: 1, from: "second", to: "day", expected: 0, unit: "d" },
+    { value: 1, from: "second", to: "week", expected: 0, unit: "wk" },
+    { value: 1, from: "minute", to: "millisecond", expected: 60000, unit: "ms" },
+    { value: 1, from: "minute", to: "second", expected: 60, unit: "s" },
+    { value: 1, from: "minute", to: "hour", expected: 0.0167, unit: "h" },
+    { value: 1, from: "minute", to: "day", expected: 0.0007, unit: "d" },
+    { value: 1, from: "minute", to: "week", expected: 0.0001, unit: "wk" },
+    { value: 1, from: "hour", to: "millisecond", expected: 3600000, unit: "ms" },
+    { value: 1, from: "hour", to: "minute", expected: 60, unit: "min" },
+    { value: 1, from: "hour", to: "second", expected: 3600, unit: "s" },
+    { value: 1, from: "hour", to: "day", expected: 0.0417, unit: "d" },
+    { value: 1, from: "hour", to: "week", expected: 0.006, unit: "wk" },
+    { value: 1, from: "day", to: "millisecond", expected: 86400000, unit: "ms" },
+    { value: 1, from: "day", to: "minute", expected: 1440, unit: "min" },
+    { value: 1, from: "day", to: "hour", expected: 24, unit: "h" },
+    { value: 1, from: "day", to: "second", expected: 86400, unit: "s" },
+    { value: 1, from: "day", to: "week", expected: 0.1429, unit: "wk" },
+    { value: 1, from: "week", to: "millisecond", expected: 604800000, unit: "ms" },
+    { value: 1, from: "week", to: "minute", expected: 10080, unit: "min" },
+    { value: 1, from: "week", to: "hour", expected: 168, unit: "h" },
+    { value: 1, from: "week", to: "second", expected: 604800, unit: "s" },
+    { value: 1, from: "week", to: "day", expected: 7, unit: "d" },
   ];
   const convert = new Conversion({
     decimals: 4,
@@ -162,103 +197,104 @@ describe("Test time conversions", () => {
 
   timeTests.forEach(({ value, from, to, expected }) => {
     test(`Converts ${value} ${from} to ${to}`, () => {
-      expect(convert.value(value).from(from).to(to)).toBe(expected);
+      const result = convert.value(value).from(from).to(to);
+      expect(isApproximatelyEqual(+result.value, +expected)).toBe(true);
     });
   });
 });
 
 describe("Test volumes conversions", () => {
   const volumeTests: Array<TestValues> = [
-    { value: 1, from: "liter", to: "milliliter", expected: "1000ml" },
-    { value: 1, from: "liter", to: "cubic-foot", expected: "0.0353ft^3" },
-    { value: 1, from: "liter", to: "cubic-inch", expected: "61.0237in^3" },
-    { value: 1, from: "liter", to: "cubic-meter", expected: "0.001m^3" },
-    { value: 1, from: "liter", to: "imperial-cup", expected: "3.5195cup (UK)" },
-    { value: 1, from: "liter", to: "us-legal-cup", expected: "4.2268cup (US)" },
-    { value: 1, from: "liter", to: "imperial-pint", expected: "1.7598pt (UK)" },
-    { value: 1, from: "liter", to: "us-liquid-pint", expected: "2.1134pt (US)" },
-    { value: 1, from: "liter", to: "imperial-fluid-ounce", expected: "35.1951fl oz (UK)" },
-    { value: 1, from: "milliliter", to: "liter", expected: "0.001l" },
-    { value: 1, from: "milliliter", to: "cubic-foot", expected: "0ft^3" },
-    { value: 1, from: "milliliter", to: "cubic-inch", expected: "0.061in^3" },
-    { value: 1, from: "milliliter", to: "cubic-meter", expected: "0m^3" },
-    { value: 1, from: "milliliter", to: "imperial-cup", expected: "0.0035cup (UK)" },
-    { value: 1, from: "milliliter", to: "us-legal-cup", expected: "0.0042cup (US)" },
-    { value: 1, from: "milliliter", to: "imperial-pint", expected: "0.0018pt (UK)" },
-    { value: 1, from: "milliliter", to: "us-liquid-pint", expected: "0.0021pt (US)" },
-    { value: 1, from: "milliliter", to: "imperial-fluid-ounce", expected: "0.0352fl oz (UK)" },
-    { value: 1, from: "cubic-foot", to: "liter", expected: "28.3168l" },
-    { value: 1, from: "cubic-foot", to: "milliliter", expected: "28316.85ml" },
-    { value: 1, from: "cubic-foot", to: "cubic-inch", expected: "1728.0002in^3" },
-    { value: 1, from: "cubic-foot", to: "cubic-meter", expected: "0.0283m^3" },
-    { value: 1, from: "cubic-foot", to: "us-legal-cup", expected: "119.6883cup (US)" },
-    { value: 1, from: "cubic-foot", to: "imperial-cup", expected: "99.6614cup (UK)" },
-    { value: 1, from: "cubic-foot", to: "imperial-pint", expected: "49.8307pt (UK)" },
-    { value: 1, from: "cubic-foot", to: "us-liquid-pint", expected: "59.8442pt (US)" },
-    { value: 1, from: "cubic-foot", to: "imperial-fluid-ounce", expected: "996.6138fl oz (UK)" },
-    { value: 1, from: "cubic-inch", to: "liter", expected: "0.0164l" },
-    { value: 1, from: "cubic-inch", to: "cubic-foot", expected: "0.0006ft^3" },
-    { value: 1, from: "cubic-inch", to: "milliliter", expected: "16.3871ml" },
-    { value: 1, from: "cubic-inch", to: "cubic-meter", expected: "0m^3" },
-    { value: 1, from: "cubic-inch", to: "imperial-cup", expected: "0.0577cup (UK)" },
-    { value: 1, from: "cubic-inch", to: "us-legal-cup", expected: "0.0693cup (US)" },
-    { value: 1, from: "cubic-inch", to: "imperial-pint", expected: "0.0288pt (UK)" },
-    { value: 1, from: "cubic-inch", to: "us-liquid-pint", expected: "0.0346pt (US)" },
-    { value: 1, from: "cubic-inch", to: "imperial-fluid-ounce", expected: "0.5767fl oz (UK)" },
-    { value: 1, from: "cubic-meter", to: "liter", expected: "1000l" },
-    { value: 1, from: "cubic-meter", to: "cubic-foot", expected: "35.3147ft^3" },
-    { value: 1, from: "cubic-meter", to: "cubic-inch", expected: "61023.7441in^3" },
-    { value: 1, from: "cubic-meter", to: "milliliter", expected: "1000000ml" },
-    { value: 1, from: "cubic-meter", to: "imperial-cup", expected: "3519.508cup (UK)" },
-    { value: 1, from: "cubic-meter", to: "us-legal-cup", expected: "4226.7528cup (US)" },
-    { value: 1, from: "cubic-meter", to: "imperial-pint", expected: "1759.754pt (UK)" },
-    { value: 1, from: "cubic-meter", to: "us-liquid-pint", expected: "2113.3764pt (US)" },
-    { value: 1, from: "cubic-meter", to: "imperial-fluid-ounce", expected: "35195.0797fl oz (UK)" },
-    { value: 1, from: "imperial-cup", to: "liter", expected: "0.2841l" },
-    { value: 1, from: "imperial-cup", to: "cubic-foot", expected: "0.01ft^3" },
-    { value: 1, from: "imperial-cup", to: "cubic-inch", expected: "17.3387in^3" },
-    { value: 1, from: "imperial-cup", to: "cubic-meter", expected: "0.0003m^3" },
-    { value: 1, from: "imperial-cup", to: "milliliter", expected: "284.1306ml" },
-    { value: 1, from: "imperial-cup", to: "us-legal-cup", expected: "1.2009cup (US)" },
-    { value: 1, from: "imperial-cup", to: "imperial-pint", expected: "0.5pt (UK)" },
-    { value: 1, from: "imperial-cup", to: "us-liquid-pint", expected: "0.6005pt (US)" },
-    { value: 1, from: "imperial-cup", to: "imperial-fluid-ounce", expected: "10fl oz (UK)" },
-    { value: 1, from: "us-legal-cup", to: "liter", expected: "0.2366l" },
-    { value: 1, from: "us-legal-cup", to: "cubic-foot", expected: "0.0084ft^3" },
-    { value: 1, from: "us-legal-cup", to: "cubic-inch", expected: "14.4375in^3" },
-    { value: 1, from: "us-legal-cup", to: "cubic-meter", expected: "0.0002m^3" },
-    { value: 1, from: "us-legal-cup", to: "milliliter", expected: "236.5882ml" },
-    { value: 1, from: "us-legal-cup", to: "imperial-cup", expected: "0.8327cup (UK)" },
-    { value: 1, from: "us-legal-cup", to: "imperial-pint", expected: "0.4163pt (UK)" },
-    { value: 1, from: "us-legal-cup", to: "us-liquid-pint", expected: "0.5pt (US)" },
-    { value: 1, from: "us-legal-cup", to: "imperial-fluid-ounce", expected: "8.3267fl oz (UK)" },
-    { value: 1, from: "imperial-pint", to: "liter", expected: "0.5683l" },
-    { value: 1, from: "imperial-pint", to: "cubic-foot", expected: "0.0201ft^3" },
-    { value: 1, from: "imperial-pint", to: "cubic-inch", expected: "34.6774in^3" },
-    { value: 1, from: "imperial-pint", to: "cubic-meter", expected: "0.0006m^3" },
-    { value: 1, from: "imperial-pint", to: "imperial-cup", expected: "2cup (UK)" },
-    { value: 1, from: "imperial-pint", to: "us-legal-cup", expected: "2.4019cup (US)" },
-    { value: 1, from: "imperial-pint", to: "milliliter", expected: "568.2612ml" },
-    { value: 1, from: "imperial-pint", to: "us-liquid-pint", expected: "1.2009pt (US)" },
-    { value: 1, from: "imperial-pint", to: "imperial-fluid-ounce", expected: "20fl oz (UK)" },
-    { value: 1, from: "us-liquid-pint", to: "liter", expected: "0.4732l" },
-    { value: 1, from: "us-liquid-pint", to: "cubic-foot", expected: "0.0167ft^3" },
-    { value: 1, from: "us-liquid-pint", to: "cubic-inch", expected: "28.875in^3" },
-    { value: 1, from: "us-liquid-pint", to: "cubic-meter", expected: "0.0005m^3" },
-    { value: 1, from: "us-liquid-pint", to: "imperial-cup", expected: "1.6653cup (UK)" },
-    { value: 1, from: "us-liquid-pint", to: "us-legal-cup", expected: "2cup (US)" },
-    { value: 1, from: "us-liquid-pint", to: "imperial-pint", expected: "0.8327pt (UK)" },
-    { value: 1, from: "us-liquid-pint", to: "milliliter", expected: "473.1765ml" },
-    { value: 1, from: "us-liquid-pint", to: "imperial-fluid-ounce", expected: "16.6535fl oz (UK)" },
-    { value: 1, from: "imperial-fluid-ounce", to: "liter", expected: "0.0284l" },
-    { value: 1, from: "imperial-fluid-ounce", to: "cubic-foot", expected: "0.001ft^3" },
-    { value: 1, from: "imperial-fluid-ounce", to: "cubic-inch", expected: "1.7339in^3" },
-    { value: 1, from: "imperial-fluid-ounce", to: "cubic-meter", expected: "0m^3" },
-    { value: 1, from: "imperial-fluid-ounce", to: "imperial-cup", expected: "0.1cup (UK)" },
-    { value: 1, from: "imperial-fluid-ounce", to: "us-legal-cup", expected: "0.1201cup (US)" },
-    { value: 1, from: "imperial-fluid-ounce", to: "imperial-pint", expected: "0.05pt (UK)" },
-    { value: 1, from: "imperial-fluid-ounce", to: "us-liquid-pint", expected: "0.06pt (US)" },
-    { value: 1, from: "imperial-fluid-ounce", to: "milliliter", expected: "28.4131ml" },
+    { value: 1, from: "liter", to: "milliliter", expected: 1000, unit: "ml" },
+    { value: 1, from: "liter", to: "cubic-foot", expected: 0.0353, unit: "ft^3" },
+    { value: 1, from: "liter", to: "cubic-inch", expected: 61.0237, unit: "in^3" },
+    { value: 1, from: "liter", to: "cubic-meter", expected: 0.001, unit: "m^3" },
+    { value: 1, from: "liter", to: "imperial-cup", expected: 3.5195, unit: "cup (UK)" },
+    { value: 1, from: "liter", to: "us-legal-cup", expected: 4.2268, unit: "cup (US)" },
+    { value: 1, from: "liter", to: "imperial-pint", expected: 1.7598, unit: "pt (UK)" },
+    { value: 1, from: "liter", to: "us-liquid-pint", expected: 2.1134, unit: "pt (US)" },
+    { value: 1, from: "liter", to: "imperial-fluid-ounce", expected: 35.1951, unit: "fl oz (UK)" },
+    { value: 1, from: "milliliter", to: "liter", expected: 0.001, unit: "l" },
+    { value: 1, from: "milliliter", to: "cubic-foot", expected: 0, unit: "ft^3" },
+    { value: 1, from: "milliliter", to: "cubic-inch", expected: 0.061, unit: "in^3" },
+    { value: 1, from: "milliliter", to: "cubic-meter", expected: 0, unit: "m^3" },
+    { value: 1, from: "milliliter", to: "imperial-cup", expected: 0.0035, unit: "cup (UK)" },
+    { value: 1, from: "milliliter", to: "us-legal-cup", expected: 0.0042, unit: "cup (US)" },
+    { value: 1, from: "milliliter", to: "imperial-pint", expected: 0.0018, unit: "pt (UK)" },
+    { value: 1, from: "milliliter", to: "us-liquid-pint", expected: 0.0021, unit: "pt (US)" },
+    { value: 1, from: "milliliter", to: "imperial-fluid-ounce", expected: 0.0352, unit: "fl oz (UK)" },
+    { value: 1, from: "cubic-foot", to: "liter", expected: 28.3168, unit: "l" },
+    { value: 1, from: "cubic-foot", to: "milliliter", expected: 28316.85, unit: "ml" },
+    { value: 1, from: "cubic-foot", to: "cubic-inch", expected: 1728.0002, unit: "in^3" },
+    { value: 1, from: "cubic-foot", to: "cubic-meter", expected: 0.0283, unit: "m^3" },
+    { value: 1, from: "cubic-foot", to: "us-legal-cup", expected: 119.6883, unit: "cup (US)" },
+    { value: 1, from: "cubic-foot", to: "imperial-cup", expected: 99.6614, unit: "cup (UK)" },
+    { value: 1, from: "cubic-foot", to: "imperial-pint", expected: 49.8307, unit: "pt (UK)" },
+    { value: 1, from: "cubic-foot", to: "us-liquid-pint", expected: 59.8442, unit: "pt (US)" },
+    { value: 1, from: "cubic-foot", to: "imperial-fluid-ounce", expected: 996.6138, unit: "fl oz (UK)" },
+    { value: 1, from: "cubic-inch", to: "liter", expected: 0.0164, unit: "l" },
+    { value: 1, from: "cubic-inch", to: "cubic-foot", expected: 0.0006, unit: "ft^3" },
+    { value: 1, from: "cubic-inch", to: "milliliter", expected: 16.3871, unit: "ml" },
+    { value: 1, from: "cubic-inch", to: "cubic-meter", expected: 0, unit: "m^3" },
+    { value: 1, from: "cubic-inch", to: "imperial-cup", expected: 0.0577, unit: "cup (UK)" },
+    { value: 1, from: "cubic-inch", to: "us-legal-cup", expected: 0.0693, unit: "cup (US)" },
+    { value: 1, from: "cubic-inch", to: "imperial-pint", expected: 0.0288, unit: "pt (UK)" },
+    { value: 1, from: "cubic-inch", to: "us-liquid-pint", expected: 0.0346, unit: "pt (US)" },
+    { value: 1, from: "cubic-inch", to: "imperial-fluid-ounce", expected: 0.5767, unit: "fl oz (UK)" },
+    { value: 1, from: "cubic-meter", to: "liter", expected: 1000, unit: "l" },
+    { value: 1, from: "cubic-meter", to: "cubic-foot", expected: 35.3147, unit: "ft^3" },
+    { value: 1, from: "cubic-meter", to: "cubic-inch", expected: 61023.7441, unit: "in^3" },
+    { value: 1, from: "cubic-meter", to: "milliliter", expected: 1000000, unit: "ml" },
+    { value: 1, from: "cubic-meter", to: "imperial-cup", expected: 3519.508, unit: "cup (UK)" },
+    { value: 1, from: "cubic-meter", to: "us-legal-cup", expected: 4226.7528, unit: "cup (US)" },
+    { value: 1, from: "cubic-meter", to: "imperial-pint", expected: 1759.754, unit: "pt (UK)" },
+    { value: 1, from: "cubic-meter", to: "us-liquid-pint", expected: 2113.3764, unit: "pt (US)" },
+    { value: 1, from: "cubic-meter", to: "imperial-fluid-ounce", expected: 35195.0797, unit: "fl oz (UK)" },
+    { value: 1, from: "imperial-cup", to: "liter", expected: 0.2841, unit: "l" },
+    { value: 1, from: "imperial-cup", to: "cubic-foot", expected: 0.01, unit: "ft^3" },
+    { value: 1, from: "imperial-cup", to: "cubic-inch", expected: 17.3387, unit: "in^3" },
+    { value: 1, from: "imperial-cup", to: "cubic-meter", expected: 0.0003, unit: "m^3" },
+    { value: 1, from: "imperial-cup", to: "milliliter", expected: 284.1306, unit: "ml" },
+    { value: 1, from: "imperial-cup", to: "us-legal-cup", expected: 1.2009, unit: "cup (US)" },
+    { value: 1, from: "imperial-cup", to: "imperial-pint", expected: 0.5, unit: "pt (UK)" },
+    { value: 1, from: "imperial-cup", to: "us-liquid-pint", expected: 0.6005, unit: "pt (US)" },
+    { value: 1, from: "imperial-cup", to: "imperial-fluid-ounce", expected: 10, unit: "fl oz (UK)" },
+    { value: 1, from: "us-legal-cup", to: "liter", expected: 0.2366, unit: "l" },
+    { value: 1, from: "us-legal-cup", to: "cubic-foot", expected: 0.0084, unit: "ft^3" },
+    { value: 1, from: "us-legal-cup", to: "cubic-inch", expected: 14.4375, unit: "in^3" },
+    { value: 1, from: "us-legal-cup", to: "cubic-meter", expected: 0.0002, unit: "m^3" },
+    { value: 1, from: "us-legal-cup", to: "milliliter", expected: 236.5882, unit: "ml" },
+    { value: 1, from: "us-legal-cup", to: "imperial-cup", expected: 0.8327, unit: "cup (UK)" },
+    { value: 1, from: "us-legal-cup", to: "imperial-pint", expected: 0.4163, unit: "pt (UK)" },
+    { value: 1, from: "us-legal-cup", to: "us-liquid-pint", expected: 0.5, unit: "pt (US)" },
+    { value: 1, from: "us-legal-cup", to: "imperial-fluid-ounce", expected: 8.3267, unit: "fl oz (UK)" },
+    { value: 1, from: "imperial-pint", to: "liter", expected: 0.5683, unit: "l" },
+    { value: 1, from: "imperial-pint", to: "cubic-foot", expected: 0.0201, unit: "ft^3" },
+    { value: 1, from: "imperial-pint", to: "cubic-inch", expected: 34.6774, unit: "in^3" },
+    { value: 1, from: "imperial-pint", to: "cubic-meter", expected: 0.0006, unit: "m^3" },
+    { value: 1, from: "imperial-pint", to: "imperial-cup", expected: 2, unit: "cup (UK)" },
+    { value: 1, from: "imperial-pint", to: "us-legal-cup", expected: 2.4019, unit: "cup (US)" },
+    { value: 1, from: "imperial-pint", to: "milliliter", expected: 568.2612, unit: "ml" },
+    { value: 1, from: "imperial-pint", to: "us-liquid-pint", expected: 1.2009, unit: "pt (US)" },
+    { value: 1, from: "imperial-pint", to: "imperial-fluid-ounce", expected: 20, unit: "fl oz (UK)" },
+    { value: 1, from: "us-liquid-pint", to: "liter", expected: 0.4732, unit: "l" },
+    { value: 1, from: "us-liquid-pint", to: "cubic-foot", expected: 0.0167, unit: "ft^3" },
+    { value: 1, from: "us-liquid-pint", to: "cubic-inch", expected: 28.875, unit: "in^3" },
+    { value: 1, from: "us-liquid-pint", to: "cubic-meter", expected: 0.0005, unit: "m^3" },
+    { value: 1, from: "us-liquid-pint", to: "imperial-cup", expected: 1.6653, unit: "cup (UK)" },
+    { value: 1, from: "us-liquid-pint", to: "us-legal-cup", expected: 2, unit: "cup (US)" },
+    { value: 1, from: "us-liquid-pint", to: "imperial-pint", expected: 0.8327, unit: "pt (UK)" },
+    { value: 1, from: "us-liquid-pint", to: "milliliter", expected: 473.1765, unit: "ml" },
+    { value: 1, from: "us-liquid-pint", to: "imperial-fluid-ounce", expected: 16.6535, unit: "fl oz (UK)" },
+    { value: 1, from: "imperial-fluid-ounce", to: "liter", expected: 0.0284, unit: "l" },
+    { value: 1, from: "imperial-fluid-ounce", to: "cubic-foot", expected: 0.001, unit: "ft^3" },
+    { value: 1, from: "imperial-fluid-ounce", to: "cubic-inch", expected: 1.7339, unit: "in^3" },
+    { value: 1, from: "imperial-fluid-ounce", to: "cubic-meter", expected: 0, unit: "m^3" },
+    { value: 1, from: "imperial-fluid-ounce", to: "imperial-cup", expected: 0.1, unit: "cup (UK)" },
+    { value: 1, from: "imperial-fluid-ounce", to: "us-legal-cup", expected: 0.1201, unit: "cup (US)" },
+    { value: 1, from: "imperial-fluid-ounce", to: "imperial-pint", expected: 0.05, unit: "pt (UK)" },
+    { value: 1, from: "imperial-fluid-ounce", to: "us-liquid-pint", expected: 0.06, unit: "pt (US)" },
+    { value: 1, from: "imperial-fluid-ounce", to: "milliliter", expected: 28.413, unit: "ml" },
   ];
   const convert = new Conversion({
     decimals: 4,
@@ -266,7 +302,8 @@ describe("Test volumes conversions", () => {
 
   volumeTests.forEach(({ value, from, to, expected }) => {
     test(`Converts ${value} ${from} to ${to}`, () => {
-      expect(convert.value(value).from(from).to(to)).toBe(expected);
+      const result = convert.value(value).from(from).to(to);
+      expect(isApproximatelyEqual(+result.value, +expected)).toBe(true);
     });
   });
 });
@@ -290,7 +327,150 @@ describe("Test number conversions", () => {
 
   numberTests.forEach(({ value, from, to, expected }) => {
     test(`Converts ${value} ${from} to ${to}`, () => {
-      expect(convert.value(value).from(from).to(to)).toBe(expected);
+      const result = convert.value(value).from(from).to(to);
+      expect(result.value).toBe(expected);
+    });
+  });
+});
+
+describe("Test pressure conversions", () => {
+  const pressureTests: Array<TestValues> = [
+    { value: 1, from: "pascal", to: "kilopascal", expected: 0.001, unit: "kPa" },
+    { value: 1, from: "pascal", to: "atmosphere", expected: 0.0000098692, unit: "atm" },
+    { value: 1, from: "pascal", to: "bar", expected: 0.00001, unit: "bar" },
+    { value: 1, from: "pascal", to: "psi", expected: 0.0001450377, unit: "psi" },
+    { value: 1, from: "kilopascal", to: "pascal", expected: 1000, unit: "Pa" },
+    { value: 1, from: "kilopascal", to: "atmosphere", expected: 0.0098692327, unit: "atm" },
+    { value: 1, from: "kilopascal", to: "bar", expected: 0.01, unit: "bar" },
+    { value: 1, from: "kilopascal", to: "psi", expected: 0.1450377377, unit: "psi" },
+    { value: 1, from: "atmosphere", to: "pascal", expected: 101325, unit: "Pa" },
+    { value: 1, from: "atmosphere", to: "kilopascal", expected: 101.325, unit: "kPa" },
+    { value: 1, from: "atmosphere", to: "bar", expected: 1.01325, unit: "bar" },
+    { value: 1, from: "atmosphere", to: "psi", expected: 14.695948775, unit: "psi" },
+    { value: 1, from: "bar", to: "pascal", expected: 100000, unit: "Pa" },
+    { value: 1, from: "bar", to: "kilopascal", expected: 100, unit: "kPa" },
+    { value: 1, from: "bar", to: "atmosphere", expected: 0.9869232667, unit: "atm" },
+    { value: 1, from: "bar", to: "psi", expected: 14.503773773, unit: "psi" },
+    { value: 1, from: "psi", to: "pascal", expected: 6894.7572932, unit: "Pa" },
+    { value: 1, from: "psi", to: "kilopascal", expected: 6.8947572932, unit: "kPa" },
+    { value: 1, from: "psi", to: "bar", expected: 0.0689475729, unit: "bar" },
+    { value: 1, from: "psi", to: "atmosphere", expected: 0.0680459639, unit: "atm" },
+  ];
+  const convert = new Conversion();
+
+  pressureTests.forEach(({ value, from, to, expected, unit }) => {
+    test(`Converts ${value} ${from} to ${to}`, () => {
+      const result = convert.value(value).from(from).to(to);
+      expect(isApproximatelyEqual(+result.value, +expected)).toBe(true);
+      expect(result.unit).toBe(unit);
+    });
+  });
+});
+
+describe("Test energy conversions", () => {
+  const pressureTests: Array<TestValues> = [
+    { value: 1, from: "joule", to: "kilojoule", expected: 0.001, unit: "kJ" },
+    { value: 1, from: "joule", to: "calorie", expected: 0.0002388459, unit: "cal" },
+    { value: 1, from: "joule", to: "calorie-international-table", expected: 0.2388458966, unit: "cal (IT)" },
+    { value: 1, from: "joule", to: "calorie-thermochemical", expected: 0.2390057361, unit: "cal (th)" },
+    { value: 1, from: "joule", to: "watt-hour", expected: 0.0002777778, unit: "Wh" },
+    { value: 1, from: "joule", to: "kilowatt-hour", expected: 2.777777777 * 10 ** -7, unit: "kWh" },
+    { value: 1, from: "joule", to: "electron-volt", expected: 6241509074461000000, unit: "eV" },
+
+    { value: 1, from: "kilojoule", to: "joule", expected: 1000, unit: "J" },
+    { value: 1, from: "kilojoule", to: "calorie", expected: 0.2388458966, unit: "cal" },
+    { value: 1, from: "kilojoule", to: "calorie-international-table", expected: 238.84589663, unit: "cal (IT)" },
+    { value: 1, from: "kilojoule", to: "calorie-thermochemical", expected: 239.00573614, unit: "cal (th)" },
+    { value: 1, from: "kilojoule", to: "watt-hour", expected: 0.2777777778, unit: "Wh" },
+    { value: 1, from: "kilojoule", to: "kilowatt-hour", expected: 0.0002777778, unit: "kWh" },
+    { value: 1, from: "kilojoule", to: "electron-volt", expected: 6.241509074 * 10 ** 21, unit: "eV" },
+
+    { value: 1, from: "calorie", to: "joule", expected: 4186.8, unit: "J" },
+    { value: 1, from: "calorie", to: "kilojoule", expected: 4.1868, unit: "kJ" },
+    { value: 1, from: "calorie", to: "calorie-international-table", expected: 1000, unit: "cal (IT)" },
+    { value: 1, from: "calorie", to: "calorie-thermochemical", expected: 1000.6692161, unit: "cal (th)" },
+    { value: 1, from: "calorie", to: "watt-hour", expected: 1.163, unit: "Wh" },
+    { value: 1, from: "calorie", to: "kilowatt-hour", expected: 0.001163, unit: "kWh" },
+    { value: 1, from: "calorie", to: "electron-volt", expected: 2.613195019 * 10 ** 22, unit: "eV" },
+
+    { value: 1, from: "calorie-international-table", to: "joule", expected: 4.1868, unit: "J" },
+    { value: 1, from: "calorie-international-table", to: "calorie", expected: 0.001, unit: "cal" },
+    { value: 1, from: "calorie-international-table", to: "kilojoule", expected: 0.0041868, unit: "kJ" },
+    {
+      value: 1,
+      from: "calorie-international-table",
+      to: "calorie-thermochemical",
+      expected: 1.0006692161,
+      unit: "cal (th)",
+    },
+    { value: 1, from: "calorie-international-table", to: "watt-hour", expected: 0.001163, unit: "Wh" },
+    {
+      value: 1,
+      from: "calorie-international-table",
+      to: "kilowatt-hour",
+      expected: 0.000001163,
+      unit: "kWh",
+    },
+    { value: 1, from: "calorie-international-table", to: "electron-volt", expected: 26131950192952873000, unit: "eV" },
+
+    { value: 1, from: "calorie-thermochemical", to: "joule", expected: 4.184, unit: "J" },
+    { value: 1, from: "calorie-thermochemical", to: "calorie", expected: 0.0009993312, unit: "cal" },
+    {
+      value: 1,
+      from: "calorie-thermochemical",
+      to: "calorie-international-table",
+      expected: 0.9993312315,
+      unit: "cal (IT)",
+    },
+    { value: 1, from: "calorie-thermochemical", to: "kilojoule", expected: 0.004184, unit: "kJ" },
+    { value: 1, from: "calorie-thermochemical", to: "watt-hour", expected: 0.0011622222, unit: "Wh" },
+    { value: 1, from: "calorie-thermochemical", to: "kilowatt-hour", expected: 0.0000011622, unit: "kWh" },
+    { value: 1, from: "calorie-thermochemical", to: "electron-volt", expected: 26114473967544530000, unit: "eV" },
+
+    { value: 1, from: "watt-hour", to: "joule", expected: 3600, unit: "J" },
+    { value: 1, from: "watt-hour", to: "calorie", expected: 0.8598452279, unit: "cal" },
+    { value: 1, from: "watt-hour", to: "calorie-international-table", expected: 859.84522786, unit: "cal (IT)" },
+    { value: 1, from: "watt-hour", to: "calorie-thermochemical", expected: 860.4206501, unit: "cal (th)" },
+    { value: 1, from: "watt-hour", to: "kilojoule", expected: 3.6, unit: "kJ" },
+    { value: 1, from: "watt-hour", to: "kilowatt-hour", expected: 0.001, unit: "kWh" },
+    { value: 1, from: "watt-hour", to: "electron-volt", expected: 2.246943266 * 10 ** 22, unit: "eV" },
+
+    { value: 1, from: "kilowatt-hour", to: "joule", expected: 3600000, unit: "J" },
+    { value: 1, from: "kilowatt-hour", to: "calorie", expected: 859.84522786, unit: "cal" },
+    { value: 1, from: "kilowatt-hour", to: "calorie-international-table", expected: 859845.22786, unit: "cal (IT)" },
+    { value: 1, from: "kilowatt-hour", to: "calorie-thermochemical", expected: 860420.6501, unit: "cal (th)" },
+    { value: 1, from: "kilowatt-hour", to: "watt-hour", expected: 1000, unit: "Wh" },
+    { value: 1, from: "kilowatt-hour", to: "kilojoule", expected: 3600, unit: "kJ" },
+    { value: 1, from: "kilowatt-hour", to: "electron-volt", expected: 2.246943266 * 10 ** 25, unit: "eV" },
+
+    { value: 1, from: "electron-volt", to: "joule", expected: 1.602176633 * 10 ** -19, unit: "J" },
+    { value: 1, from: "electron-volt", to: "calorie", expected: 3.826733147 * 10 ** -23, unit: "cal" },
+    {
+      value: 1,
+      from: "electron-volt",
+      to: "calorie-international-table",
+      expected: 3.826733147 * 10 ** -20,
+      unit: "cal (IT)",
+    },
+    {
+      value: 1,
+      from: "electron-volt",
+      to: "calorie-thermochemical",
+      expected: 3.829294058 * 10 ** -20,
+      unit: "cal (th)",
+    },
+    { value: 1, from: "electron-volt", to: "watt-hour", expected: 4.450490649 * 10 ** -23, unit: "Wh" },
+    { value: 1, from: "electron-volt", to: "kilojoule", expected: 1.602176633 * 10 ** -22, unit: "kJ" },
+    { value: 1, from: "electron-volt", to: "kilowatt-hour", expected: 4.450490649 * 10 ** -26, unit: "kWh" },
+  ];
+
+  const convert = new Conversion();
+
+  pressureTests.forEach(({ value, from, to, expected, unit }) => {
+    test(`Converts ${value} ${from} to ${to}`, () => {
+      const result = convert.value(value).from(from).to(to);
+      expect(isApproximatelyEqual(+result.value, +expected)).toBe(true);
+      expect(result.unit).toBe(unit);
     });
   });
 });


### PR DESCRIPTION
- Support for pressure and energy unit conversion
- The return type of a conversion would now be an object with the value and unit 
- Test cases have been updated to consider precision changes to the config
- `includeUnit` option has been deprecated in favour of the new way the converted value is returned. It is the user's choice to use the unit from the return object.